### PR TITLE
Feature/equipment

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,6 +5,7 @@
 *	SID - added equipment checks. Special values for "RNAV" and "NON-RNAV" are available or single equipment codes can be set to mandatory or forbidden (each SID defaults to RNAV mandatory)
 *	SID - added faa to icao equipment code conversion based on Topsky internal conversion to adapt to a possible error during communication of ES, Topsky and Vatsim servers
 *	SID - added destination restriction option. If ADES ICAO is found in the list but is forbidden (false) the SID is skipped. If it is not found in the list but there is at least one mandatory (true) the SID is skipped.
+*	SID (item) - special "EQUIP" instead of "MANUAL" display if no SID was found and the last possible check failed due to equipment missmatches
 *	Airport - each airport can have equipment checks enabled or disabled in the config (defaults to enabled)
 
 [CHANGED]

--- a/flightplan.cpp
+++ b/flightplan.cpp
@@ -223,7 +223,9 @@ std::string vsid::fpln::getEquip(const EuroScopePlugIn::CFlightPlan &FlightPlan)
 									equip + "\". Reported capability \"" + cap + "\"", vsid::MessageHandler::DebugArea::Sid);
 
 		std::map<char, std::string> faaToIcao = {
-			{'X', "SF"}, {'T', "SF"}, {'U', "SF"},
+			// X disabled due to too many occurences with fplns that are RNAV capable
+			//{'X', "SF"},
+			{'T', "SF"}, {'U', "SF"},
 			{'D', "SDF"}, {'B', "SDF"}, {'A', "SDF"},
 			{'M', "DFILTUV"}, {'N', "DFILTUV"}, {'P', "DFILTUV"},
 			{'Y', "SDFIRY"}, {'C', "SDFIRY"}, {'I', "SDFIRY"},

--- a/flightplan.h
+++ b/flightplan.h
@@ -43,6 +43,7 @@ namespace vsid
 			std::chrono::time_point<std::chrono::utc_clock, std::chrono::seconds> lastUpdate;
 			int updateCounter = 0;
 			bool request = false;
+			bool validEquip = true;
 		};
 
 		/**


### PR DESCRIPTION
* Disabling FAA code 'X'
* Adding special value 'EQUIP' to SID tagItem if the last possible SID failed due to an equipment mismatch