### PR TITLE
Add option for request info next to tag (and others)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,7 +6,7 @@
 *	SID - new function to set the ground state to "startup" in addition to the new clearance function (#277)
 *	GEN - error caching added for errors that are subject to euroscope update rates. Errors that might be thrown on controller action are not cached (#296)
 *	DIS - new configurable (which screen to display on, color and display enable/disable) pushback indicator - a small arrow left to the radar target when the gnd state is push
-*	REQ - new "rwy startup" request list. Request are switchable between startup and rwy startup, i.e. the request time of the first request is transfered between those lists. The new list is usable to check the startup position for that specific runway. To see the global position again one can switch back to regular startup. As of now each flight plan only exists in ONE of both lists (#145)
+*	REQ - new "rwy startup" request list. Requests are switchable between startup and rwy startup. The new list is usable to check the startup position for that specific runway. To see the global position again one can switch back to regular startup. (#145)
 
 **CHANGED**
 *	GEN - removed "vSID" from items as it is already written in the dropdown menu (this also mean that in the item type list vSID is not displayed anymore)

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -22,6 +22,7 @@
 *	GEN - renamed func "CTL" to "Set cleared to land flag"
 *	GEN - renamed func "CLR + SID" to "Set CRF and SID"
 *	GEN - renamed func "CLR + SID + SU" to "Set CRF, SID and Startup state"
+*	GEN - changed / improved flight plan info storing during flight plan updates (attempt for #214)
 
 **FIXED**
 *	SID - possible wrong result in SID determination if waypoint doesn't match base and SID is entered in the flight plan (#304)

--- a/airport.h
+++ b/airport.h
@@ -77,7 +77,20 @@ namespace vsid
 		int maxInitialClimb = 0;
 		std::map<std::string, bool> settings = {};
 		std::map<std::string, vsid::Controller> controllers = {};
+		//************************************
+		// Description: Stores requests during airport updates
+		// Param 1: std::string - request type
+		// Param 2 (pair): std::string - callsign
+		// Param 3 (pair): long long - time
+		//************************************
 		std::map<std::string, std::set<std::pair<std::string, long long>, compreq>> requests = {};
+		//************************************
+		// Description: Stores runway requests
+		// Param 1: std::string - request type
+		// Param 2: std::string - runway
+		// Param 3 (pair): std::string - callsign
+		// Param 4 (pair): long long - time
+		//************************************
 		std::map<std::string, std::map< std::string, std::set<std::pair<std::string, long long>, compreq>>> rwyrequests = {};
 		bool forceAuto = false;
 		/**

--- a/constants.h
+++ b/constants.h
@@ -107,3 +107,5 @@ const std::string ERROR_CONF_DISPLAY = "E052";
 const std::string ERROR_CMD_ATCICAO = "E060";
 
 const std::string ERROR_ATC_ICAOSPLIT = "E070";
+
+const std::string ERROR_REQ_RWYSPLIT = "E080";

--- a/flightplan.cpp
+++ b/flightplan.cpp
@@ -348,3 +348,26 @@ std::string vsid::fplnhelper::getPbn(const EuroScopePlugIn::CFlightPlan& FlightP
 	}
 	return "";
 }
+
+void vsid::fplnhelper::saveFplnInfo(const std::string& callsign, vsid::Fpln fplnInfo, std::map<std::string, vsid::Fpln>& savedFplnInfo)
+{
+	savedFplnInfo[callsign] = std::move(fplnInfo);
+
+	savedFplnInfo[callsign].sid = {};
+	savedFplnInfo[callsign].customSid = {};
+	savedFplnInfo[callsign].sidWpt = "";
+	savedFplnInfo[callsign].transition = "";
+	savedFplnInfo[callsign].validEquip = true;
+}
+
+bool vsid::fplnhelper::restoreFplnInfo(const std::string& callsign, std::map<std::string, vsid::Fpln>& processed, std::map<std::string, vsid::Fpln>& savedFplnInfo)
+{
+	if (!savedFplnInfo.contains(callsign)) return false;
+
+	processed[callsign] = std::move(savedFplnInfo[callsign]);
+
+	savedFplnInfo.erase(callsign);
+
+	if (processed.contains(callsign)) return true;
+	else return false;
+}

--- a/flightplan.h
+++ b/flightplan.h
@@ -43,7 +43,8 @@ namespace vsid
 		std::string transition = "";
 		std::chrono::time_point<std::chrono::utc_clock, std::chrono::seconds> lastUpdate;
 		int updateCounter = 0;
-		bool request = false;
+		/*bool request = false;*/
+		std::string request = "";
 		bool validEquip = true;
 		std::string gndState = "";
 		bool ctl = false;

--- a/flightplan.h
+++ b/flightplan.h
@@ -207,5 +207,37 @@ namespace vsid
 		// Parameter: const EuroScopePlugIn::CFlightPlan & FlightPlan
 		//************************************
 		std::string getPbn(const EuroScopePlugIn::CFlightPlan& FlightPlan);
+
+		//************************************
+		// Description: Stores flight plan info
+		// Method:    saveFplnInfo
+		// FullName:  vsid::fplnhelper::saveFplnInfo
+		// Access:    public 
+		// Returns:   void
+		// Qualifier:
+		// Parameter: const std::string & callsign
+		// Parameter: vsid::Fpln fplnInfo
+		// Parameter: std::map<std::string
+		// Parameter: vsid::Fpln> & savedFplnInfo
+		//************************************
+		void saveFplnInfo(const std::string& callsign, vsid::Fpln fplnInfo,
+			std::map<std::string, vsid::Fpln>& savedFplnInfo);
+
+
+		//************************************
+		// Description: Restores flight plan info if callsign has stored info
+		// Method:    restoreFplnInfo
+		// FullName:  vsid::fplnhelper::restoreFplnInfo
+		// Access:    public 
+		// Returns:   bool
+		// Qualifier:
+		// Parameter: const std::string & callsign
+		// Parameter: std::map<std::string
+		// Parameter: vsid::Fpln> & processed
+		// Parameter: std::map<std::string
+		// Parameter: vsid::Fpln> & savedFplnInfo
+		//************************************
+		bool restoreFplnInfo(const std::string& callsign, std::map<std::string, vsid::Fpln>& processed,
+			std::map<std::string, vsid::Fpln>& savedFplnInfo);
 	}
 }

--- a/menu.cpp
+++ b/menu.cpp
@@ -508,7 +508,7 @@ void vsid::Menu::update()
 						messageHandler->writeMessage("DEBUG", "[" + txt.title + "] base area mismatch, base.bottom smaller", vsid::MessageHandler::DebugArea::Menu);
 					}
 				}
-				else if (txt.base.bottom > txt.area.bottom + txt.margin.bottom) // #dev - test for bottom bar movement after deletion
+				else if (txt.base.bottom > txt.area.bottom + txt.margin.bottom)
 				{
 					if (txt.base == this->area)
 					{

--- a/messageHandler.cpp
+++ b/messageHandler.cpp
@@ -39,6 +39,36 @@ void vsid::MessageHandler::writeMessage(std::string sender, std::string msg, Deb
 	
 }
 
+void vsid::MessageHandler::writeMessage(std::string sender, std::string msg, const std::source_location& loc, DebugArea debugArea)
+{
+	if (sender == "DEBUG" && this->getLevel() != Level::Debug) return;
+
+	try
+	{
+		if (this->currentLevel == Level::Debug && (this->debugArea == debugArea || this->debugArea == DebugArea::All) && sender == "DEBUG")
+		{
+			std::string area;
+			if (debugArea == DebugArea::Atc) area = "ATC";
+			else if (debugArea == DebugArea::Conf) area = "CONF";
+			else if (debugArea == DebugArea::Dev) area = "DEV";
+			else if (debugArea == DebugArea::Req) area = "REQ";
+			else if (debugArea == DebugArea::Rwy) area = "RWY";
+			else if (debugArea == DebugArea::Sid) area = "SID";
+			else if (debugArea == DebugArea::Menu) area = "MENU";
+			else area = "N/A";
+
+			std::cout << "[" << vsid::time::toTimeString(vsid::time::getUtcNow()) << "] [" << area << "] " << msg
+				<< " | file: " << loc.file_name() << " | func: " << loc.function_name() << " | " << " line: " << loc.line() << '\n';
+		}
+		else if (/*this->currentLevel != Level::Debug && */sender != "DEBUG") this->msg.push_back(std::pair<std::string, std::string>(sender, msg));
+	}
+	catch (std::exception& e)
+	{
+		this->msg.push_back(std::pair<std::string, std::string>("ERROR", e.what()));
+	}
+
+}
+
 std::pair<std::string, std::string> vsid::MessageHandler::getMessage()
 {
 	if (this->msg.size() > 0)

--- a/messageHandler.h
+++ b/messageHandler.h
@@ -27,6 +27,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <vector>
 
+#include <source_location> // #dev - add source_location
+
 namespace vsid
 {
 	/**
@@ -66,6 +68,8 @@ namespace vsid
 		 * @param msg 
 		 */
 		void writeMessage(std::string sender, std::string msg, DebugArea debugArea = DebugArea::All);
+
+		void writeMessage(std::string sender, std::string msg, const std::source_location& loc, DebugArea debugArea = DebugArea::All);
 		/**
 		 * @brief Retrieve the first message from the local message stack
 		 * 

--- a/vSIDPlugin.h
+++ b/vSIDPlugin.h
@@ -60,7 +60,6 @@ namespace vsid
 		virtual ~VSIDPlugin();
 
 		inline std::map<std::string, vsid::Fpln>& getProcessed() { return this->processed; };
-		/*inline std::map<std::string, vsid::fpln::Info>& getProcessed() { return this->processed; };*/ // #removal - old fpln::Info
 		inline std::set<std::string> getDepRwy(std::string icao)
 		{
 			if (this->activeAirports.contains(icao))
@@ -238,7 +237,6 @@ namespace vsid
 	private:
 		std::map<std::string, vsid::Airport> activeAirports;
 		std::map<std::string, vsid::Fpln> processed;
-		/*std::map<std::string, vsid::fpln::Info> processed;*/ // #removal old fpln::Info
 		/**
 		 * @param std::map<std::string,> callsign
 		 * @param std::pair<,bool> fpln is disconnected
@@ -249,8 +247,24 @@ namespace vsid
 		std::map<std::string, std::map<std::string, bool>> savedSettings;
 		std::map<std::string, std::map<std::string, bool>> savedRules;
 		std::map<std::string, std::map<std::string, vsid::Area>> savedAreas;
+		std::map<std::string, vsid::Fpln> savedFplnInfo = {};
+		//************************************
+		// Description: Stores requests during airport updates
+		// Param 1: std::string - airport icao
+		// Param 2: std::string - request type
+		// Param 3 (pair): std::string - callsign
+		// Param 4 (pair): long long - time
+		//************************************
 		std::map<std::string, std::map<std::string, std::set<std::pair<std::string, long long>, vsid::Airport::compreq>>> savedRequests = {};
-		std::map<std::string, std::map<std::string, std::map<std::string, std::set<std::pair<std::string, long long>, vsid::Airport::compreq>>>> savedRwyRequests = {}; // #rwy req
+		//************************************
+		// Description: Stores runway requests during airport updates
+		// Param 1: std::string - airport icao
+		// Param 2: std::string - request type
+		// Param 3: std::string - runway
+		// Param 4 (pair): std::string - callsign
+		// Param 5 (pair): long long - time
+		//************************************
+		std::map<std::string, std::map<std::string, std::map<std::string, std::set<std::pair<std::string, long long>, vsid::Airport::compreq>>>> savedRwyRequests = {};
 		// list of ground states set by controllers
 		std::string gsList;
 		std::map<std::string, std::string> actAtc;

--- a/vSidConfig.json
+++ b/vSidConfig.json
@@ -1,5 +1,5 @@
 {
-    "airportConfigs": "config",
+    "airportConfigs": "../vSID Airportconfig",
     "colors": {
         "sidSuggestion": {
             "r": 255,
@@ -111,7 +111,12 @@
 			"g": 10,
 			"b": 10
         },
-        "pbIndicator": {"r": 0, "g": 255, "b": 0}
+      "pbIndicator": {
+        "r": 0,
+        "g": 255,
+        "b": 0
+      },
+      "reqIndicator": {"r":  255, "g":  255, "b":  255}
     },
     "requests": {
         "caution": 2,
@@ -125,6 +130,8 @@
     },
     "display": {
         "showPbIndicatorOn": "Ground Radar display",
-        "enablePbIndicator": true
+        "enablePbIndicator": true,
+        "showRequestOn": "Ground Radar display",
+        "enableRequest":  true
     }
 }


### PR DESCRIPTION
- updated flight plan info storage (might resolve #214)
- parallel lists for request and rwy request (only startup now) - time is preserved, lists can be switched