### PR TITLE
New dynamic zoom for indicator (inters only atm)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -11,6 +11,7 @@
 				"25C": "L1, L3, L6"
 			}
 	```
+	* for pre-configured intersections the scratch pad can be used to set them ("+": set, "-": able; e.g. +L6). The intersection needs to be exclusive, so no other entries can be present in the scratch pad
 *	FPLN - intersections are shown below the target similar to request and pushback indicators
 *	CONF - add health check for SID number mismatches in .sct or .ese files
 

--- a/configparser.cpp
+++ b/configparser.cpp
@@ -422,7 +422,7 @@ void vsid::ConfigParser::loadAirportConfig(std::map<std::string, vsid::Airport> 
     std::vector<std::filesystem::path> files;
     std::set<std::string> aptConfig;
 
-   /* for (const std::filesystem::path& entry : std::filesystem::recursive_directory_iterator(basePath)) // needs further #evaluation - can cause slow loading
+   /* for (const std::filesystem::path& entry : std::filesystem::recursive_directory_iterator(basePath)) // needs further #evaluate - can cause slow loading
     {
         if (!std::filesystem::is_directory(entry) && entry.extension() == ".json")
         {

--- a/display.h
+++ b/display.h
@@ -173,6 +173,11 @@ namespace vsid
 			return coordTL.DistanceTo(coordBR);
 		}
 
+		inline double getScreenDiagonalPx()
+		{
+			return std::hypot(this->GetRadarArea().right, this->GetRadarArea().bottom);
+		}
+
 		inline int getZoomLevel()
 		{
 			// #dev - get display distance
@@ -181,6 +186,28 @@ namespace vsid
 			return (std::round(getScreenNM() * 100.0) / 100.0) * 100.0;
 
 			// end dev - get display distance
+		}
+
+		inline double getLabelOffset()
+		{
+			// #dev - constant factor for zooming
+			const double refOffset = 20;
+			const double refNM = 417;
+			const double refDiagPx = 2144.40;
+
+			// double refPxPerNm = refNM / this->getScreenDiagonalPx();
+			double refPxPerNm = refDiagPx / refNM;
+
+			double gapNM = refOffset / refPxPerNm;
+
+			double pxPerNm = this->getScreenDiagonalPx() / this->getZoomLevel();
+			// double offsetPx = factor / this->getZoomLevel() / 2;
+
+			// double offset = refOffset * (refPxPerNm / pxPerNm); - without log scale
+			//double beta = 1.0;
+			/*double offset = refOffset * std::log2(1.0 + beta * (refPxPerNm / pxPerNm));*/
+			return gapNM * pxPerNm;
+			// end dev
 		}
 	};
 }


### PR DESCRIPTION
* in addition: intersection scratch pad entries (+ for set, - for able with the intersection, e.g. +L6 ; no other entry is allowed to be present)