### PR TITLE
fix (GEN): Version control checks

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,8 +6,9 @@
 	* the pdb file is generated during the build process
 
 :lady_beetle: **Fixes**
-*	CONF - fix UB during coordinate conversion during the parsing of the .ese file for atc stations and vis points
-	* might need further investigation. On random occasions the conversion of coordinates from the .ese file caused an access violation, possible due to wrong / missing values from the ese file (reason unknown / if related to ES itself)
+*	CONF - fix crash during coordinate conversion while parsing the .ese file for atc stations and vis points
+	* due to a wrong coordinate in the .ese file the split was wrong and parameters missing - now guarded against
+*	GEN - version check could report newer remote version if minor or patch was newer but major was older
 
 [Changelog v0.14.4]
 :gear: **Changed Features / Behaviour**

--- a/area.cpp
+++ b/area.cpp
@@ -59,38 +59,6 @@ vsid::Area::Point vsid::Area::toPoint(std::pair<std::string, std::string> &pos)
 	return {lat, lon};
 }
 
-//double vsid::Area::toDeg(std::string& coord)
-//{
-//	std::vector<std::string> dms = vsid::utils::split(coord, '.');
-//	int multi = 0; // default state in exception case
-//
-//	try
-//	{
-//		if (dms.size() < 4)
-//			throw std::out_of_range("Coordinate string \"" + coord + "\" does not contain enough parts for DMS conversion!");
-//
-//		multi = (dms.at(0).find('S') != std::string::npos || dms.at(0).find('W') != std::string::npos) ? -1 : 1;
-//
-//		double deg = std::stod(dms[0].substr(1, dms[0].length()));
-//		double min = std::stod(dms[1]) / 60;
-//		double sec = (std::stod(dms[2]) + std::stod("0." + dms[3])) / 3600;
-//
-//		return (deg + min + sec) * multi;
-//	}
-//	catch (std::out_of_range &e)
-//	{
-//		messageHandler->writeMessage("ERROR", "Out of bounds while calculating coordinate: " + coord + ". " + e.what());
-//	}
-//	catch (const std::invalid_argument& e)
-//	{
-//		messageHandler->writeMessage("ERROR", "Invalid number format in coord " + coord + ". " + e.what());
-//	}
-//
-//	messageHandler->writeMessage("WARNING", "Fallback state for \"" + coord + "\"! Failed to calculate. DMS will be set to 0.0");
-//
-//	return 0.0;
-//}
-
 bool vsid::Area::inside(const EuroScopePlugIn::CPosition& fplnPos)
 {
 	std::pair<Point, Point> l5 = { {fplnPos.m_Latitude, fplnPos.m_Longitude}, {fplnPos.m_Latitude + 0.05, fplnPos.m_Longitude + 0.05} };

--- a/area.h
+++ b/area.h
@@ -70,13 +70,5 @@ namespace vsid
 		 * @param pos the fpln position as pair of lat/long coordinates
 		 */
 		Point toPoint(std::pair<std::string, std::string> &pos);
-
-		/**
-		 * @brief Transforms lat/long string value into decimal equivalent // #refactor - change to utils.h version
-		 * 
-		 * @param coord 
-		 * @return double 
-		 */
-		/*double toDeg(std::string& coord);*/
 	};
 }

--- a/versionchecker.cpp
+++ b/versionchecker.cpp
@@ -41,34 +41,26 @@ std::string vsid::version::semverToString(const vsid::version::semver& v)
 
 int vsid::version::compSemVer(const vsid::version::semver& local, const vsid::version::semver& remote)
 {
-	if (!std::get<3>(remote))
+	// get base version (major, minor, patch)
+	auto baseLocal = std::tie(std::get<0>(local), std::get<1>(local), std::get<2>(local));
+	auto baseRemote = std::tie(std::get<0>(remote), std::get<1>(remote), std::get<2>(remote));
+
+	bool remoteIsStable = !std::get<3>(remote);
+	bool localIsStable = !std::get<3>(local);
+
+	if (baseRemote > baseLocal) return remoteIsStable ? 1 : 2; // remote is newer, 1 = stable, 2 = pre-release
+
+	if (baseRemote == baseLocal)
 	{
-		if (std::get<0>(remote) > std::get<0>(local) ||
-			std::get<1>(remote) > std::get<1>(local) ||
-			std::get<2>(remote) > std::get<2>(local))
+		if (!remoteIsStable && !localIsStable)
 		{
+			if (std::get<3>(remote) != std::get<3>(local)) return 2; // assumed new pre-release
+		}
+		else if (remoteIsStable && !localIsStable)
 			return 1; // new stable release
-		}
-	}
-	else
-	{
-		if ((std::get<0>(remote) > std::get<0>(local) ||
-			std::get<1>(remote) > std::get<1>(local) ||
-			std::get<2>(remote) > std::get<2>(local)) &&
-			std::get<3>(remote) != std::get<3>(local))
-		{
-			return 2; // assumed new pre-release
-		}
-		else if (std::get<0>(remote) == std::get<0>(local) &&
-			std::get<1>(remote) == std::get<1>(local) &&
-			std::get<2>(remote) == std::get<2>(local) &&
-			std::get<3>(remote) != std::get<3>(local))
-		{
-			return 2; // assumed new pre-release, only hash differs
-		}
 	}
 
-	return 0;
+	return 0; // default state - no update
 }
 
 std::optional<std::string> vsid::version::getHttp(bool prerelease)


### PR DESCRIPTION
Remote version could be reported as newer when a local version was reset to 0 e.g. in patch but the remote version was still higher in patch (but actually lower in minor)