### PR TITLE
fix (ATC): Wrong cleanup after ATC disconnection with new callsign storage

### DIFF
--- a/timeHandler.cpp
+++ b/timeHandler.cpp
@@ -26,16 +26,3 @@ bool vsid::time::isActive(const std::string& timezone, const int start, const in
 	}
 	return false;
 }
-
-std::string vsid::time::getFormattedTime(std::chrono::system_clock::time_point tp, std::string_view fmtStr)
-{
-	std::time_t time = std::chrono::system_clock::to_time_t(tp);
-	std::tm tm{};
-	gmtime_s(&tm, &time);
-
-	std::array<char, 64> timeBuffer;
-
-	if (std::strftime(timeBuffer.data(), timeBuffer.size(), fmtStr.data(), &tm) > 0) return std::string(timeBuffer.data());
-
-	return "TIME_ERROR";
-}

--- a/timeHandler.h
+++ b/timeHandler.h
@@ -66,10 +66,25 @@ namespace vsid
 		// Access:    public 
 		// Returns:   std::string
 		// Qualifier:
-		// Parameter: std::chrono::system_clock::time_point tp
+		// Parameter: const std::chrono::time_point<T
+		// Parameter: U> & tp
 		// Parameter: std::string_view fmtStr
 		//************************************
-		std::string getFormattedTime(std::chrono::system_clock::time_point tp = std::chrono::system_clock::now(), std::string_view fmtStr = "%Y-%m-%d %H:%M:%S");
+		template<typename T, typename U>
+		std::string getFormattedTime(const std::chrono::time_point<T, U>& tp, std::string_view fmtStr = "%Y-%m-%d %H:%M:%S")
+		{
+			auto sysTp = std::chrono::clock_cast<std::chrono::system_clock>(tp);
+
+			std::time_t time = std::chrono::system_clock::to_time_t(sysTp);
+			std::tm tm{};
+			gmtime_s(&tm, &time);
+
+			std::array<char, 64> timeBuffer;
+
+			if (std::strftime(timeBuffer.data(), timeBuffer.size(), fmtStr.data(), &tm) > 0) return std::string(timeBuffer.data());
+
+			return "TIME_ERROR";
+		}
 
 		//************************************
 		// Description: Caches timezone and provides fallback if timezone unavailable
@@ -136,9 +151,24 @@ namespace vsid
 			return std::string(std::format("{:%Y.%m.%d %H:%M:%S}", timePoint));
 		}
 
+		//************************************
+		// Description: Transform a timepoint into a time string
+		// Method:    toTimeString
+		// FullName:  vsid::time::toTimeString
+		// Access:    public 
+		// Returns:   std::string
+		// Qualifier:
+		// Parameter: const std::chrono::time_point<T
+		// Parameter: U> & timePoint
+		//************************************
 		template<typename T, typename U>
 		std::string toTimeString(const std::chrono::time_point<T, U>& timePoint)
 		{
+			if (vsid::utils::usingWine())
+			{
+				return vsid::time::getFormattedTime(timePoint, "%H:%M:%S");
+			}
+
 			return std::string(std::format("{:%H:%M:%S}", timePoint));
 		}
 	}

--- a/vSIDPlugin.cpp
+++ b/vSIDPlugin.cpp
@@ -3847,10 +3847,10 @@ bool vsid::VSIDPlugin::OnCompileCommand(const char* sCommandLine)
 
 						std::string atcList;
 						bool first = true;
-						for (const auto& [_, controller] : airport.controllers)
+						for (const auto& [atcCallsign, controller] : airport.controllers)
 						{
 							if (!first) atcList += " | ";
-							atcList += controller.si;
+							atcList += std::format("{} ({})", atcCallsign, controller.si);
 							first = false;
 						}
 						vsid::Logger::log(LogLevel::Debug, std::format("[{}] Own ATC Facility: {}. Own ATC ICAO: {}. "
@@ -3893,7 +3893,7 @@ bool vsid::VSIDPlugin::OnCompileCommand(const char* sCommandLine)
 				}
 				else vsid::Logger::log(LogLevel::Info, "No new automode. Check .vsid auto status for active ones.");
 			}
-			else if (cmd.params.size() == 1)
+			else if (cmd.params.size() >= 1)
 			{
 				// string populating with apt states and delimiter for non-first entries
 				bool first = true;
@@ -3915,21 +3915,20 @@ bool vsid::VSIDPlugin::OnCompileCommand(const char* sCommandLine)
 						vsid::Logger::log(LogLevel::Info, autoList);
 					else
 						vsid::Logger::log(LogLevel::Info, "No active automode.");
+
+					return true;
 				}
-				else if (vsid::utils::svEqualCi(cmd.params[0], "off"))
+
+				if (vsid::utils::svEqualCi(cmd.params[0], "off"))
 				{
 					for (auto& [icao, airport] : this->activeAirports)
 					{
 						airport.settings["auto"] = false;
 					}
 					vsid::Logger::log(LogLevel::Info, "Automode OFF for all airports.");
+
+					return true;
 				}
-			}
-			else if (cmd.params.size() > 1)
-			{
-				// string populating with apt states and delimiter for non-first entries
-				bool first = true;
-				std::string autoList;
 
 				for (const auto& param : cmd.params)
 				{
@@ -3940,7 +3939,7 @@ bool vsid::VSIDPlugin::OnCompileCommand(const char* sCommandLine)
 
 						if (myFacility >= 2 && myFacility <= 4 && !vsid::utils::svEqualCi(atcIcao, param))
 						{
-							vsid::Logger::log(LogLevel::Debug, std::format("[{}] Skipping force auto mode because own ATC ICAO does not match", param),
+							vsid::Logger::log(LogLevel::Debug, std::format("[{}] Skipping (force) auto mode because own ATC ICAO does not match", param),
 								vsid::DebugLevel::Atc);
 
 							continue;
@@ -3948,7 +3947,7 @@ bool vsid::VSIDPlugin::OnCompileCommand(const char* sCommandLine)
 
 						if (myFacility > 4 && !airport.appSI.contains(atcSI) && !vsid::utils::svEqualCi(atcIcao, param))
 						{
-							vsid::Logger::log(LogLevel::Debug, std::format("[{}] Skipping force auto mode because own SI is not in apt appSI or "
+							vsid::Logger::log(LogLevel::Debug, std::format("[{}] Skipping (force) auto mode because own SI is not in apt appSI or "
 								"own ATC ICAO does not match", param), vsid::DebugLevel::Atc);
 
 							continue;
@@ -4513,6 +4512,9 @@ bool vsid::VSIDPlugin::OnCompileCommand(const char* sCommandLine)
 
 			return true;
 		}
+
+		vsid::Logger::log(LogLevel::Info, std::format("Unknown command [{}].", cmd.command));
+		return false;
 	}
 
 	vsid::Logger::log(LogLevel::Warning, std::format("Failed to parse command [{}]. It is probably invalid.", sCommandLine));
@@ -4523,6 +4525,7 @@ bool vsid::VSIDPlugin::OnCompileCommand(const char* sCommandLine)
 void vsid::VSIDPlugin::OnFlightPlanFlightPlanDataUpdate(EuroScopePlugIn::CFlightPlan FlightPlan)
 {
 	if (!FlightPlan.IsValid()) return;
+	if (this->outOfVis(FlightPlan)) return;
 
 	// if we receive updates for flight plans validate entered sid again to sync between controllers
 	// updates are received for any flight plan not just that under control
@@ -4744,6 +4747,7 @@ void vsid::VSIDPlugin::OnFlightPlanFlightPlanDataUpdate(EuroScopePlugIn::CFlight
 void vsid::VSIDPlugin::OnFlightPlanControllerAssignedDataUpdate(EuroScopePlugIn::CFlightPlan FlightPlan, int DataType)
 {
 	if (!FlightPlan.IsValid()) return;
+	if (this->outOfVis(FlightPlan)) return;
 
 	EuroScopePlugIn::CFlightPlanControllerAssignedData cad = FlightPlan.GetControllerAssignedData();
 	std::string callsign = FlightPlan.GetCallsign();
@@ -5230,6 +5234,9 @@ void vsid::VSIDPlugin::OnControllerPositionUpdate(EuroScopePlugIn::CController C
 	{
 		if (failit->second >= MAX_ATC_FAIL_COUNT)
 		{
+			vsid::Logger::log(LogLevel::Debug, std::format("[{}] Adding to ignore list after reaching max_atc_fail_count.", atcCallsign),
+				vsid::DebugLevel::Atc);
+
 			this->ignoredAtc.insert({ atcCallsign, data });
 			return;
 		}
@@ -5262,6 +5269,14 @@ void vsid::VSIDPlugin::OnControllerPositionUpdate(EuroScopePlugIn::CController C
 	if (atcCallsign.ends_with("FMP"))
 	{
 		vsid::Logger::log(LogLevel::Debug, std::format("[{}] Adding FMP station to ignore list.", atcCallsign), vsid::DebugLevel::Atc);
+
+		this->ignoredAtc.insert({ atcCallsign, data });
+		return;
+	}
+
+	if (atcCallsign.ends_with("SUP"))
+	{
+		vsid::Logger::log(LogLevel::Debug, std::format("[{}] Adding SUP station to ignore list.", atcCallsign), vsid::DebugLevel::Atc);
 
 		this->ignoredAtc.insert({ atcCallsign, data });
 		return;
@@ -5447,7 +5462,6 @@ void vsid::VSIDPlugin::OnControllerPositionUpdate(EuroScopePlugIn::CController C
 void vsid::VSIDPlugin::OnControllerDisconnect(EuroScopePlugIn::CController Controller)
 {
 	std::string atcCallsign = Controller.GetCallsign();
-	std::string atcSI = Controller.GetPositionId();
 
 	if (auto it = this->activeAtc.find(atcCallsign); it != this->activeAtc.end())
 	{
@@ -5458,7 +5472,7 @@ void vsid::VSIDPlugin::OnControllerDisconnect(EuroScopePlugIn::CController Contr
 			vsid::Logger::log(LogLevel::Debug, std::format("[{}] disconnected. Removing from ATC list for [{}].", atcCallsign,
 				icao), vsid::DebugLevel::Atc);
 
-			airport.controllers.erase(atcSI);
+			airport.controllers.erase(atcCallsign);
 		}
 
 		vsid::Logger::log(LogLevel::Debug, std::format("[{}] disconnected. Removing from general active ATC list.", atcCallsign), vsid::DebugLevel::Atc);


### PR DESCRIPTION
* move getFormattedTime to header as template
* add two more outOfVis checks
* add SUPs to ignoreAtc